### PR TITLE
Add webmcp-sdk — full WebMCP developer toolkit (core, React, security, testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [opentiny/next-sdk](https://github.com/opentiny/next-sdk) - Frontend AI SDK with `WebMcpServer`/`WebMcpClient` classes, transport adapters (MessageChannel, SSE, HTTP), Zod validation, and Vue 3 chat UI component.
 - [jasonjmcghee/WebMCP](https://github.com/jasonjmcghee/WebMCP) - Early WebMCP prototype by [@jasonjmcghee](https://github.com/jasonjmcghee) with client-side widget and localhost WebSocket bridge. NPM package and Docker support. Pre-dates the W3C spec; not spec-compliant.
 
+- [webmcp-sdk](https://github.com/up2itnow/webmcp-sdk) ([npm](https://www.npmjs.com/package/webmcp-sdk)) - Full TypeScript developer toolkit for making websites agent-ready via WebMCP. Includes core, React, security, and testing packages.
 ## Framework Libraries
 
 - [@mcp-b/react-webmcp](https://www.npmjs.com/package/@mcp-b/react-webmcp) - React hooks (`useWebMCP`, `useMcpTool`) for registering and invoking WebMCP tools.


### PR DESCRIPTION
## What is this?

[webmcp-sdk](https://www.npmjs.com/package/webmcp-sdk) is a full WebMCP developer toolkit — core, React, security, and testing modules. Build agent-ready websites with `navigator.modelContext`.

## Key features
- Core WebMCP implementation + React hooks
- Built-in security layer (rate limiting, auth, CORS)
- Testing utilities for agent interactions
- Works with Chrome 146+ declarative and imperative WebMCP
- MIT licensed

## Links
- npm: https://www.npmjs.com/package/webmcp-sdk
- GitHub: https://github.com/up2itnow0822/webmcp-sdk