### PR TITLE
Add WebMCP List to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The [Security and Privacy Considerations](https://github.com/webmachinelearning/
 - [Automation: webmcp-monthly-roundup](https://github.com/joellobo1234/webmcp-monthly-roundup-gh-action) - GitHub Action generating monthly newsletter roundups of WebMCP repo activity.
 - [r/HowToAIAgent](https://www.reddit.com/r/HowToAIAgent/comments/1r36bec/webmcp_just_dropped_in_chrome_146_and_now_your/) - Chrome 146 launch discussion.
 - [r/ClaudeCode](https://www.reddit.com/r/ClaudeCode/comments/1r2m8cw/chromes_webmcp_makes_ai_agents_stop_pretending/) - Developer reactions.
+- [WebMCP List](https://webmcplist.com) - Open directory of WebMCP-enabled websites with search, category browsing, and community submissions. Itself WebMCP-enabled with 4 tools for AI agent discovery.
 
 ---
 


### PR DESCRIPTION
## Add WebMCP List (webmcplist.com)

[webmcplist.com](https://webmcplist.com) is an open directory of WebMCP-enabled websites.

**What it does:**
- Browse and search WebMCP-enabled sites by category
- Community submission form with tool listing
- Admin review workflow for quality control
- Full SEO with structured data, sitemap, robots.txt, llms.txt

**WebMCP-enabled:** The directory itself registers 4 tools via `navigator.modelContext`:
- `search_webmcp_sites` — Search the directory
- `list_webmcp_categories` — List all categories
- `get_webmcp_site` — Get details for a specific site
- `submit_webmcp_site` — Submit a new site

**Why Community section:** It's a community resource for discovering WebMCP-enabled websites, complementing the spec docs and discussion channels already listed.

**Open source:** [github.com/keptlive/webmcp-directory](https://github.com/keptlive/webmcp-directory)