### PR TITLE
Add webmaxru WebMCP skill to Starter Templates & Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 
 - [CodelyTV/webmcp-course](https://github.com/CodelyTV/webmcp-course) - Course examples for both [declarative](https://github.com/webmachinelearning/webmcp/pull/76) (`toolname`/`tooldescription` attributes) and [imperative](https://webmachinelearning.github.io/webmcp) (`navigator.modelContext`) APIs. Tied to [Codely Pro Spanish course](https://pro.codely.com/library/webmcp-anade-capacidades-agenticas-a-tu-web).
 - [taqm/webmcp-sample](https://github.com/taqm/webmcp-sample) - Next.js + TypeScript starter template with Bun runtime, Biome linting, and Git hooks.
+- [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill with template assets for implementing and debugging browser WebMCP integrations in JavaScript or TypeScript apps.
 - [opentiny/docs](https://github.com/opentiny/docs) - Unified VitePress documentation for the OpenTiny NEXT ecosystem covering `WebMcpClient`, `WebMcpServer`, MCP browser extensions, and related projects.
 
 ## Analysis & Readiness Tools


### PR DESCRIPTION
## Summary
- add the WebMCP skill from webmaxru/agent-skills
- place it in Starter Templates & Courses because it ships reusable guidance plus template assets for implementing browser WebMCP integrations

## Why this fits
This resource is directly about the WebMCP browser standard and helps developers implement and debug navigator.modelContext integrations in existing JavaScript or TypeScript apps.