### PR TITLE
Add @stevysmith/agentk (Framework Libraries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 ## Framework Libraries
 
 - [@mcp-b/react-webmcp](https://www.npmjs.com/package/@mcp-b/react-webmcp) - React hooks (`useWebMCP`, `useMcpTool`) for registering and invoking WebMCP tools.
+- [@stevysmith/agentk](https://github.com/stevysmith/agentk) - Command palette (cmdk fork) where JSON Schema tool defs become human-facing forms and WebMCP registrations; handles the `document.modelContext` rename and AbortSignal unregistration. Runs in production at [stacktr.ee](https://stacktr.ee).
 
 ## Browser Extensions
 


### PR DESCRIPTION
Command palette library (cmdk fork): JSON Schema tools register as WebMCP tools alongside auto-generated human forms. In production at stacktr.ee (Chrome origin trial).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@stevysmith/agentk` to the Framework Libraries section in the README. It’s a `cmdk`-based command palette that turns JSON Schema tool definitions into human-facing forms and WebMCP tool registrations, handles the `document.modelContext` rename and AbortSignal unregistration, and is live in production at stacktr.ee.

<sup>Written for commit 597ee9fc67dca413e9f95c64a0f4b77bd643877b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

