### PR TITLE
Add webmcp-lint to Analysis & Readiness Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 ## Analysis & Readiness Tools
 
 - [AI Agent Readiness Scanner](https://scanner.v1be.codes) ([source](https://github.com/ckorhonen/ai-agent-scanner)) - Free tool to score any website's AI agent readiness across 6 categories: WebMCP support, semantic HTML, structured data, llms.txt, crawlability, and content quality. Returns a grade (A–F), a 5-level readiness label (Invisible → AI-Native), per-check fix instructions with code examples, and supports side-by-side competitor comparison.
+- [munzzyy/webmcp-lint](https://github.com/munzzyy/webmcp-lint) - Security and spec-correctness linter for WebMCP tool manifests with human, JSON, or SARIF output for CI.
 
 ## Reference
 


### PR DESCRIPTION
webmcp-lint checks a WebMCP tool manifest against Chrome's security guidance before it ships: read-only hints, untrusted-content flags, prompt injection in tool descriptions, unconstrained parameters. Output is human, JSON, or SARIF, so it drops into CI.

It's my project, so the usual disclosure applies. MIT, tested, README with a demo of real output. One link per the guidelines; I'm adding the DevTools panel in a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `munzzyy/webmcp-lint` to the Analysis & Readiness Tools list in the README. It’s a security and spec-correctness linter for WebMCP tool manifests with human, JSON, and SARIF output for CI.

<sup>Written for commit 80aa0c49089e77ef819c797deeb8547177e40b9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

