### PR TITLE
Add webmcp-devtools to Browser Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [igrigorik/AgentBoard](https://github.com/igrigorik/AgentBoard) - AI switchboard extension by [@igrigorik](https://github.com/igrigorik) with multi-provider LLM sidebar (OpenAI, Anthropic, Google, Ollama), scriptable WebMCP tools running in page context, remote MCP server support, and command templates.
 - [amedina/agentic-web-learning-tool](https://github.com/amedina/agentic-web-learning-tool) - Chrome extension framework for agentic AI workflows, visual workflow composition, MCP server integration, and Chrome built-in AI playground.
 - [WebMCP-org/char-plugin](https://github.com/WebMCP-org/char-plugin) - Claude Code plugin that installs Char embeddable AI agent, configures WebMCP servers, [registers tools](https://github.com/webmachinelearning/webmcp/issues/15), and provides `/char:setup` wizard.
+- [munzzyy/webmcp-devtools](https://github.com/munzzyy/webmcp-devtools) - Chrome DevTools panel that inspects and security-lints the WebMCP tools a page exposes, with a live tool table, call-history timeline, and per-tool poisoning checks.
 
 ## Bridges & Adapters
 


### PR DESCRIPTION
webmcp-devtools is a Chrome DevTools panel for the WebMCP tools a page exposes: a live tool table, a call-history timeline, and per-tool tool-poisoning checks. Plain JavaScript, no build step.

Also mine, same disclosure. MIT, tested where Chrome APIs allow, README documents what the test suite can and can't cover. One link per the guidelines; the manifest linter went in a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `webmcp-devtools` to the Browser Extensions section in the README, pointing to a Chrome DevTools panel for inspecting WebMCP tools. It shows a live tool table, call-history timeline, and per-tool poisoning checks to help debugging and security review.

<sup>Written for commit 9c92c65178b91262087510d6d166d7d67bfe9064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

