### PR TITLE
Add image2svg to Demo Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [Doriandarko/webmcp-starter](https://github.com/Doriandarko/webmcp-starter) - Single-file "Midnight Eats" DoorDash-style demo with 9 tools (8 [imperative](https://webmachinelearning.github.io/webmcp), 1 [declarative](https://github.com/webmachinelearning/webmcp/pull/76)) and zero dependencies.
 - [alecron/webmcp-demo](https://github.com/alecron/webmcp-demo) - Notes app with 5 tools (add, list, search, delete, stats) using [`navigator.modelContext.provideContext()`](https://webmachinelearning.github.io/webmcp).
 - [alanw707/webmcp-readiness-radar](https://github.com/alanw707/webmcp-readiness-radar) - Web app scoring a site's WebMCP agent-readiness with pillar-wise breakdown and recommendations.
+- [image2svg](https://botmonster.com/image2svg/) - Free image to SVG converter with WebMCP tools, plus post search and share tools on the parent blog.
 
 ## Starter Templates & Courses
 


### PR DESCRIPTION
## Summary
- add image2svg, a free in-browser image to SVG converter with WebMCP tools, to Demo Applications

## Why this fits
Live public site using the WebMCP browser standard. Tools are registered on the converter page and site-wide on the parent blog (post search, sharing), active in the Chrome 149 origin trial.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add image2svg to the Demo Applications list. It’s a live image‑to‑SVG converter using WebMCP tools, with site‑wide post search/share tools on the parent blog, and is active in the Chrome 149 origin trial.

<sup>Written for commit a60ab514b43ce29ea3b4b9b49863d44be466c2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

