### PR TITLE
Add WindTunnel benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@
 
 - [AI Agent Readiness Scanner](https://scanner.v1be.codes) ([source](https://github.com/ckorhonen/ai-agent-scanner)) - Free tool to score any website's AI agent readiness across 6 categories: WebMCP support, semantic HTML, structured data, llms.txt, crawlability, and content quality. Returns a grade (A–F), a 5-level readiness label (Invisible → AI-Native), per-check fix instructions with code examples, and supports side-by-side competitor comparison.
 
+## Benchmarks
+
+- [WindTunnel](https://github.com/nekuda-ai/WindTunnel) - Open-source benchmark comparing WebMCP with other browser-agent interfaces across task success, execution time, token usage, and cost.
+
 ## Reference
 
 Deep-dive material lives in [docs/](docs/): [Specification](docs/specification.md) | [API reference](docs/api-reference.md) | [Security](docs/security.md) | [Articles & talks](docs/reading.md) | [Community](docs/community.md) | [Key people](docs/key-people.md)


### PR DESCRIPTION
Adds WindTunnel under a new Benchmarks section. It is a public, open-source benchmark directly focused on WebMCP, comparing it with other browser-agent interfaces across task success, execution time, token usage, and cost.

A new section is used because the existing categories do not cover evaluation benchmarks. The link was verified successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Benchmarks section to the README and links to WindTunnel, an open-source benchmark focused on WebMCP. This helps readers find objective comparisons across task success, execution time, token usage, and cost.

- Docs-only change; no runtime, API, or build impact.
- New section created because existing categories did not cover evaluation benchmarks.
- Link verified working.

<sup>Written for commit 8cade7e018eb55349791d39758138cba5c7f6be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

