### PR TITLE
Add simple-webmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 ## Framework Libraries
 
 - [@mcp-b/react-webmcp](https://www.npmjs.com/package/@mcp-b/react-webmcp) - React hooks (`useWebMCP`, `useMcpTool`) for registering and invoking WebMCP tools.
+- [simple-webmcp](https://github.com/emingure/simple-webmcp) - Turns existing JavaScript and TypeScript functions into callable WebMCP tools via `webmcp(fn)`, avoiding a separate tool layer while supporting schema patching, React lifecycle helpers, and execution hooks for approvals and analytics.
 
 ## Browser Extensions
 


### PR DESCRIPTION
Adds `simple-webmcp`, a function-first WebMCP library that turns existing JavaScript/TypeScript functions into callable tools while supporting schema patching, React lifecycle integration, and execution hooks for approvals and analytics.

Repository: https://github.com/emingure/simple-webmcp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `simple-webmcp` to the README's framework libraries list, promoting a function-first WebMCP library that turns existing JavaScript/TypeScript functions into callable tools via `webmcp(fn)`.

<sup>Written for commit 89adb99c2896edc508d80aeb58eed4a767f37229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

