### PR TITLE
Add Production Implementations section with Orshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@
 - [alecron/webmcp-demo](https://github.com/alecron/webmcp-demo) - Notes app with 5 tools (add, list, search, delete, stats) using [`navigator.modelContext.provideContext()`](https://webmachinelearning.github.io/webmcp).
 - [alanw707/webmcp-readiness-radar](https://github.com/alanw707/webmcp-readiness-radar) - Web app scoring a site's WebMCP agent-readiness with pillar-wise breakdown and recommendations.
 
+## Production Implementations
+
+- [Orshot](https://orshot.com) - Visual content generation platform with WebMCP tools live in production: template search, pricing, and docs tools for visitors, plus its full hosted-MCP toolset bridged onto `document.modelContext` for logged-in sessions.
+
 ## Starter Templates & Courses
 
 - [CodelyTV/webmcp-course](https://github.com/CodelyTV/webmcp-course) - Course examples for both [declarative](https://github.com/webmachinelearning/webmcp/pull/76) (`toolname`/`tooldescription` attributes) and [imperative](https://webmachinelearning.github.io/webmcp) (`navigator.modelContext`) APIs. Tied to [Codely Pro Spanish course](https://pro.codely.com/library/webmcp-anade-capacidades-agenticas-a-tu-web).


### PR DESCRIPTION
Adds a **Production Implementations** section (per contributing.md, justifying the new category here: the Demo Applications section is all demos/starters, and live production sites with WebMCP tools are starting to exist — a distinct, useful thing to track).

First entry: **Orshot** (orshot.com), a visual content generation platform with WebMCP live in production as of Aug 31:

- 6 public tools for visitors (template search/details/open, live pricing, page-markdown reader, MCP connect pointer), registered on `document.modelContext` with a `navigator.modelContext` fallback
- For logged-in sessions, its full hosted-MCP toolset (90 tools) is bridged onto `document.modelContext`: the page exchanges the session for a short-lived first-party OAuth token, discovers tools via stateless `tools/list`, and proxies `execute` → `tools/call`

Verifiable in ChatGPT's browser or Chrome with the WebMCP flag: `document.modelContext.getTools()` on orshot.com. Also listed/pending on the webmcp.com directory.

Format follows the guide: one entry, one sentence, no badges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Production Implementations section to the README, with Orshot as the first entry.

The existing Demo Applications section is for demos and starters, so this gives live production WebMCP sites a distinct place to be tracked. Orshot exposes 6 public tools for visitors and bridges its full hosted-MCP toolset onto `document.modelContext` for logged-in sessions.

<sup>Written for commit acf34f4fa6d7d666dbc41d7836356e851e27a451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

