### PR TITLE
Add scvd.store to Payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 
 ## Payment
 
+- [scvd.store](https://scvd.store) - Live x402 general store for AI agents with a parallel WebMCP surface: four read-only tools (read_store_guide, preflight_endpoint, check_conformance, verify_artifact) registered via navigator.modelContext alongside the store's own funded x402 payment flow.
 - [webmcp-payments](https://www.npmjs.com/package/webmcp-payments) - x402 payment acceptance middleware for WebMCP tools. Enables websites to charge AI agents per tool invocation using the HTTP 402 payment protocol with inline pricing metadata.
 
 ## Platforms


### PR DESCRIPTION
## What

Adds scvd.store under Payment: a live production site combining x402 payment with a WebMCP surface, alongside the existing middleware entries.

## Why it fits here specifically

The two existing entries (webmcp-payments, webmcp-platform) are libraries/middleware, not live examples. scvd.store is a running production instance of the same combination: real x402 USDC payments (Base/Polygon/Solana) plus four read-only WebMCP tools registered via `navigator.modelContext`:
- `read_store_guide` - machine-readable guide/menu
- `preflight_endpoint` - free pre-payment simulation of any x402 endpoint's client-selection logic
- `check_conformance` - free x402 v2 conformance checking against any issuer's signed offers/receipts
- `verify_artifact` - independent verification of a signed certificate

The WebMCP tools are deliberately read-only (per this list's own quality bar - nothing that moves money registers on navigator.modelContext); the store's separate x402 flow is where payment actually happens. Happy to move this to Demo Applications instead if that's judged a better fit - flagging the reasoning either way per the contributing guide.

## Checklist

- [x] WebMCP-specific (navigator.modelContext), not general server MCP
- [x] Live, working, has meaningful documentation
- [x] One link, one PR
- [x] Format matches: `- [Name](url) - Description ending with a period.`
- [x] No star counts/badges, no promotional language


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scvd.store to the Payment section as a live production example of x402 payments with a WebMCP surface. Previously, only middleware libraries were listed; this adds a working site with four read-only WebMCP tools and a real payment flow.

<sup>Written for commit 7f413a982276a2f05188da483fcc0f7ac860bb7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yigitkonur/awesome-webmcp/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

